### PR TITLE
 issue #792 Results.kt

### DIFF
--- a/core/src/main/kotlin/in/specmatic/core/Results.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Results.kt
@@ -6,7 +6,7 @@ data class Results(val results: List<Result> = emptyList()) {
     fun hasResults(): Boolean = results.isNotEmpty()
 
     fun hasFailures(): Boolean = results.any { it is Result.Failure }
-    fun success(): Boolean = !hasFailures()
+    fun success(): Boolean = successCount > 0 && failureCount == 0
 
     fun withoutFluff(fluffLevel: Int): Results = copy(results = results.filterNot { it.isFluffy(fluffLevel) })
 


### PR DESCRIPTION
Fix .success() method in Results #792

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Here i have Fix the `success()` method in the Results class.
<!-- Why are these changes necessary? -->

**Why**:The `success()` method should return `true` if there are one or more successes and no failures. The current implementation does not check if there are no failures. This fix is necessary to correctly determine whether there are any failures.

<!-- How were these changes implemented? -->

**How**:I have updated the `success()` method in the `Results` class to check if there are successes (`Result.Success`) and no failures (`Result.Failure`). The method now returns `true` only when there are one or more successes and no failures.


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [ ] Tests
- [ ] Sonar Quality Gate

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
